### PR TITLE
Enabled GitHub actions to build PDF file on push

### DIFF
--- a/.github/workflows/latex.yml
+++ b/.github/workflows/latex.yml
@@ -1,0 +1,19 @@
+name: Build document with LaTeX
+
+on: [push]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v1
+    - name: Install texlive-full
+      run: sudo apt-get install texlive-full
+    - name: Run a multi-line script
+      run: (cd latex; latexmk -pdf main.tex)
+    - uses: actions/upload-artifact@v1
+      with:
+        name: main.pdf document
+        path: latex/main.pdf

--- a/.github/workflows/latex.yml
+++ b/.github/workflows/latex.yml
@@ -15,5 +15,5 @@ jobs:
       run: (cd latex; latexmk -pdf main.tex)
     - uses: actions/upload-artifact@v1
       with:
-        name: main.pdf document
+        name: rise-doc
         path: latex/main.pdf


### PR DESCRIPTION
The compiled PDF files can be downloaded by clicking the "Artifacts" button in the upper-right hand corner ↗️ of the Actions detailed page, e.g. here: https://github.com/rise-lang/doc/commit/d7972bd0e87f9e204fedd8cb5ea19e68e2f49c5e/checks?check_suite_id=402789798